### PR TITLE
fix: change red warning symbol to missing image png for least reached

### DIFF
--- a/pages/pray/lap.js
+++ b/pages/pray/lap.js
@@ -977,7 +977,7 @@ jQuery(document).ready(function(){
     if ( data.image_url ) {
       image = '<p class="mt-3 mb-3"><img src="'+data.image_url+'" class="img-fluid" alt="" /></p>'
     } else {
-      image = '<p class="mt-3 mb-3 font-weight-bold six-em"><i class="ion-android-warning red"></i></p>'
+      image = '<p class="mt-3 mb-3"><img class="img-fluid" src="'+jsObject.nope+'" alt="" /></p>'
     }
     div.append(
       `<div class="container block">


### PR DESCRIPTION
This image is currently being used for missing people group images.

![image](https://user-images.githubusercontent.com/9816214/202488674-1f3ae36e-fa15-4b7e-8eae-470128edcf1b.png)

Should we just use this?