### PR TITLE
feat: make responsive table open all rows by default

### DIFF
--- a/pages/assets/css/basic.css
+++ b/pages/assets/css/basic.css
@@ -672,3 +672,9 @@ strong {
 .video-image-link {
     cursor: pointer;
 }
+
+/* Datatable styles */
+
+.dtr-title {
+    font-weight: bold;
+}

--- a/pages/challenges/active-list.js
+++ b/pages/challenges/active-list.js
@@ -59,7 +59,26 @@ jQuery(document).ready(function() {
       jQuery('#list-table').DataTable({
         lengthChange: false,
         pageLength: 30,
-        responsive: true,
+        responsive: {
+          details: {
+              display: $.fn.dataTable.Responsive.display.childRowImmediate,
+              type: '',
+              renderer: function ( api, rowIdx, columns ) {
+                var data = $.map( columns, function ( col, i ) {
+                    return col.hidden ?
+                        '<tr data-dt-row="'+col.rowIndex+'" data-dt-column="'+col.columnIndex+'">'+
+                            '<td class="dtr-title">'+col.title+':'+'</td> '+
+                            '<td class="dtr-data">'+col.data+'</td>'+
+                        '</tr>' :
+                        '';
+                } ).join('');
+ 
+                return data ?
+                    $('<table/>').append( data ) :
+                    false;
+            },
+          },
+        },
         order: [[0, 'desc']],
         columnDefs: [
           {


### PR DESCRIPTION
resolves #50 by setting all rows to be open by default.

Plusside: The user won't be confused by hidden information

The downside to this approach is that it takes up a lot of vertical space.

would look like this
![image](https://user-images.githubusercontent.com/9816214/203732100-fb3df3bf-8a63-4680-b7e3-1c99eeba056a.png)
