### PR TITLE
feat: reduce font-size of heatmap title and head padding

### DIFF
--- a/pages/pray/heatmap.css
+++ b/pages/pray/heatmap.css
@@ -100,7 +100,7 @@ progress {
 
 @media (max-width: 576px) {
     #head_block {
-        padding: 1em 1em;
+        padding: 1em 0.7em;
     }
 
     #foot_block {
@@ -182,7 +182,7 @@ progress {
 
 @media (max-width: 576px) {
     .navbar .two-em {
-        font-size: 1.3em;
+        font-size: 1.25em;
     }
 }
 

--- a/pages/pray/heatmap.css
+++ b/pages/pray/heatmap.css
@@ -99,6 +99,10 @@ progress {
 }
 
 @media (max-width: 576px) {
+    #head_block {
+        padding: 1em 1em;
+    }
+
     #foot_block {
         padding: 0.5em 0.7em 1em;
     }
@@ -175,6 +179,13 @@ progress {
         padding-top: 0;
     }
 }
+
+@media (max-width: 576px) {
+    .navbar .two-em {
+        font-size: 1.3em;
+    }
+}
+
 @keyframes spin {
     0% {
         transform: rotate(0deg);

--- a/pages/race/race-map.php
+++ b/pages/race/race-map.php
@@ -152,7 +152,7 @@ class Prayer_Global_Porch_Stats_Race_Map extends DT_Magic_Url_Base
                     <div class="map-overlay" id="map-legend" data-map-type="<?php echo $this->map_type ?>"></div>
                     <div class="row">
                         <div class="col col-12 center"><button type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas_stats"><i class="ion-chevron-up two-em"></i></button></div>
-                        <div class="col col-4 col-sm-3 center">
+                        <div class="col col-6 col-sm-3 center">
                             <strong>Warriors</strong>
                             <br>
                             <div class="d-flex align-items-center justify-content-center">
@@ -162,7 +162,7 @@ class Prayer_Global_Porch_Stats_Race_Map extends DT_Magic_Url_Base
                                 </div>
                             </div>
                         </div>
-                        <div class="col col-6 col-sm-3 center"><strong>Minutes Prayed</strong><br><span class="one-em"><?php echo esc_html( $lap_stats['minutes_prayed'] ) ?></span></div>
+                        <div class="col col-6 col-sm-3 center"><strong>Minutes&nbsp;Prayed</strong><br><span class="one-em"><?php echo esc_html( $lap_stats['minutes_prayed'] ) ?></span></div>
                         <div class="col col-6 col-sm-3 center"><strong>World Prayer Coverage</strong><br><span class="one-em"><?php echo esc_html( $finished_laps ) ?> times</span></div>
                         <div class="col col-6 col-sm-3 center"><strong>Time Elapsed</strong><br><span class="one-em time_elapsed" id="time_elapsed"></span></div>
                     </div>


### PR DESCRIPTION
resolves #75 

On smallest screens:

reduced the horizontal padding to match the footer padding more closely and make more space for the title
reduced the navbar two-em to make fit on one line on smallest screens

At 320px (the smallest screen we need to worry about)
![image](https://user-images.githubusercontent.com/9816214/204242057-393cc5b9-df90-44d1-a693-950ab842a35d.png)
