### PR TITLE
Relay/user locations

### DIFF
--- a/pages/pray/action-custom-lap.php
+++ b/pages/pray/action-custom-lap.php
@@ -496,11 +496,15 @@ class PG_Custom_Prayer_App_Lap extends PG_Custom_Prayer_App {
         }
 
         $new_value = (int) $report['value'] + 1;
-        /* update the report */
-        Disciple_Tools_Reports::update( [
-            'id' => $data['report_id'],
-            'value' => $new_value,
-        ] );
+        if ( $new_value <= 60 ){
+            /* update the report */
+            global $wpdb;
+            $wpdb->query( $wpdb->prepare( "
+                UPDATE $wpdb->dt_reports
+                SET value = value + 1
+                WHERE id = %d
+            ", $data['report_id'] ) );
+        }
 
         return $new_value;
     }

--- a/pages/pray/action-custom-lap.php
+++ b/pages/pray/action-custom-lap.php
@@ -472,8 +472,6 @@ class PG_Custom_Prayer_App_Lap extends PG_Custom_Prayer_App {
         switch ( $params['action'] ) {
             case 'correction':
                 return $this->save_correction( $params['parts'], $params['data'] );
-            case 'ip_location':
-                return $this->get_ip_location();
             case 'increment_prayer_time':
                 return $this->increment_prayer_time( $params['parts'], $params['data'] );
             default:
@@ -576,22 +574,6 @@ class PG_Custom_Prayer_App_Lap extends PG_Custom_Prayer_App {
         }
 
         return DT_Posts::create_post( 'feedback', $fields, true, false );
-    }
-
-    public function get_ip_location() {
-        if ( is_user_logged_in() ) {
-            $user_id = get_current_user_id();
-
-            return get_user_meta( $user_id, PG_NAMESPACE . 'location', true );
-        } else {
-            $response = DT_Ipstack_API::get_location_grid_meta_from_current_visitor();
-            if ( $response ) {
-                $response['hash'] = hash( 'sha256', serialize( $response ). mt_rand( 1000000, 10000000000000000 ) );
-                $array = array_reverse( explode( ', ', $response['label'] ) );
-                $response['country'] = $array[0] ?? '';
-            }
-            return $response;
-        }
     }
 }
 PG_Custom_Prayer_App_Lap::instance();

--- a/pages/pray/action-global-lap.php
+++ b/pages/pray/action-global-lap.php
@@ -87,8 +87,6 @@ class PG_Global_Prayer_App_Lap extends PG_Global_Prayer_App {
                 return $this->increment_prayer_time( $params['parts'], $params['data'] );
             case 'correction':
                 return $this->save_correction( $params['parts'], $params['data'] );
-            case 'ip_location':
-                return $this->get_ip_location();
             default:
                 return new WP_Error( __METHOD__, 'Incorrect action', [ 'status' => 400 ] );
         }

--- a/pages/pray/action-global-location.php
+++ b/pages/pray/action-global-location.php
@@ -163,8 +163,6 @@ class PG_Global_Prayer_App_Location extends PG_Global_Prayer_App {
                 return $this->increment_prayer_time( $params['parts'], $params['data'] );
             case 'correction':
                 return $this->save_correction( $params['parts'], $params['data'] );
-            case 'ip_location':
-                return $this->get_ip_location();
             default:
                 return new WP_Error( __METHOD__, 'Incorrect action', [ 'status' => 400 ] );
         }

--- a/pages/pray/lap.js
+++ b/pages/pray/lap.js
@@ -393,7 +393,6 @@ function ip_location() {
       .then(function (location) {
         if (location) {
           location.date_set = Date.now();
-          localStorage.setItem("user_location", JSON.stringify(location));
           let pg_user_hash = localStorage.getItem("pg_user_hash");
           if (!pg_user_hash || pg_user_hash === "undefined") {
             localStorage.setItem("pg_user_hash", location.hash);
@@ -401,6 +400,7 @@ function ip_location() {
             location.hash = pg_user_hash;
           }
           window.user_location = location;
+          localStorage.setItem("user_location", JSON.stringify(location));
         }
       });
   }

--- a/pages/pray/lap.js
+++ b/pages/pray/lap.js
@@ -383,22 +383,26 @@ window.api_fetch = function (url, options = {}) {
 };
 
 function ip_location() {
-  return window
-    .api_fetch(`${window.pg_global.root}pg-api/v1/user/ip_location`, {
-      method: "POST",
-    })
-    .then(function (location) {
-      window.user_location = [];
-      if (location) {
-        let pg_user_hash = localStorage.getItem("pg_user_hash");
-        if (!pg_user_hash || pg_user_hash === "undefined") {
-          localStorage.setItem("pg_user_hash", location.hash);
-        } else {
-          location.hash = pg_user_hash;
+  const user_location = localStorage.getItem("user_location");
+  window.user_location = user_location ? JSON.parse(user_location) : null;
+  if ( !window.user_location || window.user_location === "undefined" ) {
+    return window
+      .api_fetch(`${window.pg_global.root}pg-api/v1/user/ip_location`, {
+        method: "POST",
+      })
+      .then(function (location) {
+        if (location) {
+          localStorage.setItem("user_location", JSON.stringify(location));
+          let pg_user_hash = localStorage.getItem("pg_user_hash");
+          if (!pg_user_hash || pg_user_hash === "undefined") {
+            localStorage.setItem("pg_user_hash", location.hash);
+          } else {
+            location.hash = pg_user_hash;
+          }
+          window.user_location = location;
         }
-        window.user_location = location;
-      }
-    });
+      });
+  }
 }
 
 /* Fly away the see more button after a little bit of scroll */

--- a/pages/pray/lap.js
+++ b/pages/pray/lap.js
@@ -383,15 +383,16 @@ window.api_fetch = function (url, options = {}) {
 };
 
 function ip_location() {
-  const user_location = localStorage.getItem("user_location2");
+  const user_location = localStorage.getItem("user_location");
   window.user_location = user_location ? JSON.parse(user_location) : null;
-  if ( !window.user_location || window.user_location === "undefined" ) {
+  if ( !window.user_location || window.user_location === "undefined" || ( window.user_location.date_set && window.user_location.date_set < Date.now() - 604800000 /*7 days in milliseconds*/ ) ) {
     return window
       .api_fetch(`${window.pg_global.root}pg-api/v1/user/ip_location`, {
         method: "POST",
       })
       .then(function (location) {
         if (location) {
+          location.date_set = Date.now();
           localStorage.setItem("user_location", JSON.stringify(location));
           let pg_user_hash = localStorage.getItem("pg_user_hash");
           if (!pg_user_hash || pg_user_hash === "undefined") {

--- a/pages/pray/lap.js
+++ b/pages/pray/lap.js
@@ -383,7 +383,7 @@ window.api_fetch = function (url, options = {}) {
 };
 
 function ip_location() {
-  const user_location = localStorage.getItem("user_location");
+  const user_location = localStorage.getItem("user_location2");
   window.user_location = user_location ? JSON.parse(user_location) : null;
   if ( !window.user_location || window.user_location === "undefined" ) {
     return window

--- a/pages/pray/trait-lap.php
+++ b/pages/pray/trait-lap.php
@@ -399,11 +399,15 @@ trait PG_Lap_Trait {
         }
 
         $new_value = (int) $report['value'] + 1;
-        /* update the report */
-        Disciple_Tools_Reports::update( [
-            'id' => $data['report_id'],
-            'value' => $new_value,
-        ] );
+        if ( $new_value <= 60 ){
+            /* update the report */
+            global $wpdb;
+            $wpdb->query( $wpdb->prepare( "
+                UPDATE $wpdb->dt_reports
+                SET value = value + 1
+                WHERE id = %d
+            ", $data['report_id'] ) );
+        }
 
         return $new_value;
     }

--- a/pages/pray/trait-lap.php
+++ b/pages/pray/trait-lap.php
@@ -480,21 +480,4 @@ trait PG_Lap_Trait {
 
         return $result;
     }
-
-    public function get_ip_location() {
-        if ( is_user_logged_in() ) {
-            $user_id = get_current_user_id();
-            $location_meta = get_user_meta( $user_id, PG_NAMESPACE . 'location', true );
-
-            return $location_meta;
-        } else {
-            $response = DT_Ipstack_API::get_location_grid_meta_from_current_visitor();
-            if ( $response ) {
-                $response['hash'] = hash( 'sha256', serialize( $response ) . mt_rand( 1000000, 10000000000000000 ) );
-                $array = array_reverse( explode( ', ', $response['label'] ) );
-                $response['country'] = $array[0] ?? '';
-            }
-            return $response;
-        }
-    }
 }


### PR DESCRIPTION
Cache the IP LOCATION in the browser so we don't have to run the api call each time.
Remove unused get_ip_location code
fix bug with hashes being reset on incrementing prayer

Todo in future:
- cache geocoded address server side
- consider using IP to location table
- the grid_id from the geolocation is never user.