### PR TITLE
Persist earned badges regardless of push eligibility

### DIFF
--- a/utilities/jobs/pg-notification-handler-job.php
+++ b/utilities/jobs/pg-notification-handler-job.php
@@ -30,6 +30,18 @@ class PG_Notification_Handler_Job extends Job {
 
             $processed_users[] = $user->ID;
 
+            // Persist newly-earned badges before the push-eligibility gates below;
+            // a badge records activity the user did and must not depend on delivery channel.
+            $new_badges = [];
+            if ( !pg_is_user_in_ab_test( $user->ID ) ) {
+                $badges_manager = new PG_Badge_Manager( $user->ID );
+                $new_badges = $badges_manager->get_newly_earned_badges();
+
+                foreach ( $new_badges as $badge ) {
+                    $badges_manager->earn_badge( $badge->get_id() );
+                }
+            }
+
             $user_notifications_permission = get_user_meta( $user->ID, PG_NAMESPACE . 'notifications_permission', true );
             $can_send_push = $user_notifications_permission === '1';
             if ( !$can_send_push ) {
@@ -48,14 +60,6 @@ class PG_Notification_Handler_Job extends Job {
             pg_switch_notifications_locale( $user_language );
 
             if ( !pg_is_user_in_ab_test( $user->ID ) ) {
-                // get the users new badges that haven't been awarded yet
-                $badges_manager = new PG_Badge_Manager( $user->ID );
-                $new_badges = $badges_manager->get_newly_earned_badges();
-
-                foreach ( $new_badges as $badge ) {
-                    $badges_manager->earn_badge( $badge->get_id() );
-                }
-
                 if ( $can_send_push && count( $new_badges ) === 1 &&
                     !PG_Notifications_Sent::is_recent( $user->ID, PG_Notification::from_badge( $new_badges[0] ) )
                 ) {


### PR DESCRIPTION
## Summary

Fixes #685.

The badge-accrual loop in `PG_Notification_Handler_Job::handle()` was nested inside the same branch as push-notification queueing, so users who opted out of push notifications (or whose device subscription went undeliverable via OneSignal's `invalid_external_user_ids` / `invalid_aliases` / `"not subscribed"` responses) silently stopped accruing badges through this handler.

A badge records activity the user *did* — it shouldn't depend on whether we can deliver a push about it.

## Change

In `utilities/jobs/pg-notification-handler-job.php`:

- Hoist the `PG_Badge_Manager::get_newly_earned_badges()` + `earn_badge()` block **above** the two `continue` skips (`!$can_send_push` at line ~35 and `!empty( $push_undeliverable_at )` at line ~39).
- Keep push queueing gated behind both of those skips, unchanged.
- The A/B-test gate (`pg_is_user_in_ab_test`) is preserved on the badge block — A/B-test users still get `$new_badges = []` and skip both accrual and push queueing.

## Effect on users

| User behavior | Before | After |
|---|---|---|
| Push enabled, qualifies for badge | Cron credits + push | Cron credits + push (same) |
| Push opted-out, qualifies mid-session, never clicks Done | **Badge never persisted** | Badge persisted within 15 min |
| Push undeliverable, qualifies for badge | **Badge never persisted** | Badge persisted within 15 min |
| Clicks Done at end of session (any push state) | Badge persisted via REST | Badge persisted via REST (same) |

This closes the gap for the "Next, Next, close-the-tab" flow that opted-out users frequently hit. The companion in-app notification surface is a separate PR.

## Test plan

- [ ] User with `notifications_permission = '1'` and no `push_undeliverable_at`: badge accrues + push queues as before
- [ ] User with `notifications_permission = '0'`: badge accrues; no push queued
- [ ] User with `notifications_permission = '1'` and `push_undeliverable_at` set: badge accrues; no push queued
- [ ] A/B-test user (`pg_is_user_in_ab_test` returns true): no badge accrual, no push queued (unchanged)
- [ ] Milestone push for `inactivity` still respects `$can_send_push && $milestone->push()`