### PR TITLE
Email fallback for badge notifications when push is unavailable

### DIFF
--- a/prayer-global-porch.php
+++ b/prayer-global-porch.php
@@ -140,6 +140,7 @@ class Prayer_Global_Porch {
         require_once( 'utilities/pg-notifications-sent.php' );
         require_once( 'utilities/jobs/pg-notification-handler-job.php' );
         require_once( 'utilities/jobs/pg-user-push-notification-job.php' );
+        require_once( 'utilities/jobs/pg-user-email-notification-job.php' );
         require_once( 'utilities/pg-notifications-scheduler.php' );
         require_once( 'classes/pg-feature-flag.php' );
         require_once( 'classes/pg-flags.php' );

--- a/utilities/jobs/pg-notification-handler-job.php
+++ b/utilities/jobs/pg-notification-handler-job.php
@@ -44,12 +44,28 @@ class PG_Notification_Handler_Job extends Job {
 
             $user_notifications_permission = get_user_meta( $user->ID, PG_NAMESPACE . 'notifications_permission', true );
             $can_send_push = $user_notifications_permission === '1';
-            if ( !$can_send_push ) {
-                continue;
-            }
 
             $push_undeliverable_at = get_user_meta( $user->ID, PG_NAMESPACE . 'push_undeliverable_at', true );
-            if ( !empty( $push_undeliverable_at ) ) {
+            $push_deliverable = empty( $push_undeliverable_at );
+
+            if ( !$can_send_push || !$push_deliverable ) {
+                // Push is not available for this user — try email fallback for badge notifications.
+                if ( !empty( $new_badges ) ) {
+                    $user_emails_permission = get_user_meta( $user->ID, PG_NAMESPACE . 'emails_permission', true );
+                    if ( $user_emails_permission === '1' ) {
+                        $user_language = get_user_meta( $user->ID, PG_NAMESPACE . 'language', true );
+                        $user_language = !empty( $user_language ) ? $user_language : 'en_US';
+                        pg_switch_notifications_locale( $user_language );
+
+                        $notification = count( $new_badges ) === 1
+                            ? PG_Notification::from_badge( $new_badges[0] )
+                            : PG_Notification::from_badges( $new_badges );
+
+                        if ( !PG_Notifications_Sent::is_recent( $user->ID, $notification ) ) {
+                            wp_queue()->push( new PG_User_Email_Notification_Job( $user, $notification, $user_language ), 15 * MINUTE_IN_SECONDS );
+                        }
+                    }
+                }
                 continue;
             }
 

--- a/utilities/jobs/pg-user-email-notification-job.php
+++ b/utilities/jobs/pg-user-email-notification-job.php
@@ -41,15 +41,97 @@ class PG_User_Email_Notification_Job extends Job {
     }
 
     private function build_body(): string {
-        $title = esc_html( $this->notification->title );
-        $message = esc_html( $this->notification->message );
-        $url = esc_url( $this->notification->url );
-        $cta = esc_html__( 'View your badges', 'prayer-global-porch' );
+        $plugin_url   = Prayer_Global_Porch::get_url_path();
+        $logo_url     = $plugin_url . 'pages/assets/images/favicons/android-chrome-192x192.png';
+        $badges_url   = $plugin_url . 'pages/assets/images/badges/';
+        $cta_url      = site_url( '/dashboard/badges/' );
+        $brand_color  = '#11224e';
+        $accent_color = '#f2944a';
 
-        return "<!DOCTYPE html><html><body style=\"font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 1.5rem; color: #333;\">
-            <h1 style=\"margin-top: 0;\">{$title}</h1>
-            <p style=\"font-size: 1.05rem; line-height: 1.5;\">{$message}</p>
-            <p><a href=\"{$url}\" style=\"display: inline-block; padding: 0.75rem 1.5rem; background: #2563eb; color: #fff; text-decoration: none; border-radius: 4px;\">{$cta}</a></p>
-        </body></html>";
+        $headline   = esc_html( $this->notification->title );
+        $cta_label  = esc_html__( 'View your badges', 'prayer-global-porch' );
+        $brand_name = 'Prayer.Global';
+        $footer_tag = esc_html__( 'Pray for every place on earth.', 'prayer-global-porch' );
+        $logo_alt   = esc_attr( $brand_name );
+
+        $badge_cards = '';
+        if ( $this->notification->category === 'badges' ) {
+            // Multi-badge: notification->data is an array of badge.to_array() entries.
+            foreach ( $this->notification->data as $b ) {
+                $badge_cards .= $this->render_badge_card(
+                    $b['title'] ?? '',
+                    $b['description_earned'] ?? '',
+                    $b['image'] ?? '',
+                    $badges_url
+                );
+            }
+        } else {
+            // Single badge: badge_title and badge_image live in data; description is the notification message.
+            $badge_cards = $this->render_badge_card(
+                $this->notification->data['badge_title'] ?? '',
+                $this->notification->message,
+                $this->notification->data['badge_image'] ?? '',
+                $badges_url
+            );
+        }
+
+        return <<<HTML
+<!DOCTYPE html>
+<html>
+<body style="margin: 0; padding: 0; background: #f5f6f8; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; color: #1f2330; line-height: 1.5;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background: #f5f6f8; padding: 32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width: 600px; width: 100%; background: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.06);">
+          <tr>
+            <td style="background: {$brand_color}; padding: 24px; text-align: center;">
+              <img src="{$logo_url}" alt="{$logo_alt}" width="56" height="56" style="display: block; margin: 0 auto 8px; border-radius: 12px;">
+              <div style="color: #ffffff; font-size: 18px; font-weight: 600; letter-spacing: 0.3px;">{$brand_name}</div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 32px 32px 16px; text-align: center;">
+              <h1 style="margin: 0 0 8px; font-size: 24px; color: {$brand_color}; font-weight: 700;">{$headline}</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 0 32px;">
+              {$badge_cards}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 16px 32px 32px; text-align: center;">
+              <a href="{$cta_url}" style="display: inline-block; padding: 14px 28px; background: {$accent_color}; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">{$cta_label}</a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 16px 32px 24px; text-align: center; border-top: 1px solid #eef0f4;">
+              <div style="font-size: 13px; color: #6b7280;">{$brand_name} &middot; {$footer_tag}</div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+HTML;
+    }
+
+    private function render_badge_card( string $title, string $description, string $image, string $badges_url ): string {
+        $title_html = esc_html( $title );
+        $desc_html  = esc_html( $description );
+        $image_tag  = '';
+        if ( $image !== '' ) {
+            $image_url = esc_url( $badges_url . $image );
+            $image_tag = "<img src=\"{$image_url}\" alt=\"{$title_html}\" width=\"160\" height=\"160\" style=\"display: block; margin: 0 auto 12px; max-width: 160px; height: auto;\">";
+        }
+        return <<<HTML
+<div style="text-align: center; padding: 8px 0 16px;">
+  {$image_tag}
+  <div style="font-size: 18px; font-weight: 600; color: #1f2330; margin-bottom: 6px;">{$title_html}</div>
+  <div style="font-size: 15px; color: #4b5563; max-width: 440px; margin: 0 auto;">{$desc_html}</div>
+</div>
+HTML;
     }
 }

--- a/utilities/jobs/pg-user-email-notification-job.php
+++ b/utilities/jobs/pg-user-email-notification-job.php
@@ -1,0 +1,55 @@
+<?php
+
+use WP_Queue\Job;
+
+class PG_User_Email_Notification_Job extends Job {
+    public int $user_id;
+    public string $user_email;
+    public string $user_language;
+    public PG_Notification $notification;
+
+    public function __construct( WP_User $user, PG_Notification $notification, string $user_language = 'en_US' ) {
+        $this->user_id = $user->ID;
+        $this->user_email = $user->user_email;
+        $this->user_language = $user_language;
+        $this->notification = $notification;
+    }
+
+    public function handle() {
+        pg_switch_notifications_locale( $this->user_language );
+
+        $subject = $this->notification->title;
+        $body = $this->build_body();
+        $headers = [ 'Content-Type: text/html; charset=UTF-8' ];
+
+        $sent = wp_mail( $this->user_email, $subject, $body, $headers );
+
+        if ( $sent === false ) {
+            if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                error_log( 'PG_User_Email_Notification_Job: failed to send email to user ' . $this->user_email );
+            }
+            return;
+        }
+
+        if ( $this->notification->category === 'badges' ) {
+            foreach ( $this->notification->data as $badge ) {
+                PG_Notifications_Sent::record( $this->user_id, PG_Notification::from_badge( PG_Badge::from_array( $badge ) ), PG_CHANNEL_EMAIL );
+            }
+        } else {
+            PG_Notifications_Sent::record( $this->user_id, $this->notification, PG_CHANNEL_EMAIL );
+        }
+    }
+
+    private function build_body(): string {
+        $title = esc_html( $this->notification->title );
+        $message = esc_html( $this->notification->message );
+        $url = esc_url( $this->notification->url );
+        $cta = esc_html__( 'View your badges', 'prayer-global-porch' );
+
+        return "<!DOCTYPE html><html><body style=\"font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 1.5rem; color: #333;\">
+            <h1 style=\"margin-top: 0;\">{$title}</h1>
+            <p style=\"font-size: 1.05rem; line-height: 1.5;\">{$message}</p>
+            <p><a href=\"{$url}\" style=\"display: inline-block; padding: 0.75rem 1.5rem; background: #2563eb; color: #fff; text-decoration: none; border-radius: 4px;\">{$cta}</a></p>
+        </body></html>";
+    }
+}

--- a/utilities/jobs/pg-user-email-notification-job.php
+++ b/utilities/jobs/pg-user-email-notification-job.php
@@ -51,7 +51,7 @@ class PG_User_Email_Notification_Job extends Job {
         $headline   = esc_html( $this->notification->title );
         $cta_label  = esc_html__( 'View your badges', 'prayer-global-porch' );
         $brand_name = 'Prayer.Global';
-        $footer_tag = esc_html__( 'Pray for every place on earth.', 'prayer-global-porch' );
+        $footer_tag = esc_html__( 'Cover the World in Prayer', 'prayer-global-porch' );
         $logo_alt   = esc_attr( $brand_name );
 
         $badge_cards = '';

--- a/utilities/pg-notification.php
+++ b/utilities/pg-notification.php
@@ -37,7 +37,10 @@ class PG_Notification {
             $message,
             $title,
             $url,
-            [],
+            [
+                'badge_title' => $badge->get_title(),
+                'badge_image' => $badge->get_image(),
+            ],
             $badge->get_id(),
             $badge->get_value()
         );


### PR DESCRIPTION
## Summary

Companion to #687. Adds an email path so users who have opted out of push (or whose device subscription is undeliverable) still receive a notification when they earn a badge — provided they've opted in to email notifications.

**Note**: This PR is stacked on `fix/badge-accrual-decouple-push` (PR #687). The base should be changed to `master` after #687 lands.

## What changed

**New: `utilities/jobs/pg-user-email-notification-job.php`** — modeled on `PG_User_Push_Notification_Job`. Sends a transactional HTML email via `wp_mail()` using the user's stored locale, then records the send to `PG_Notifications_Sent` with `PG_CHANNEL_EMAIL`.

**Updated: `utilities/jobs/pg-notification-handler-job.php`** — when push is off (`!$can_send_push`) or the device is undeliverable (`!empty( $push_undeliverable_at )`), the handler now checks for `emails_permission === '1'` and queues `PG_User_Email_Notification_Job` for any newly earned badges instead of `continue`ing immediately. The two prior separate `continue` statements are merged into a single branch so the email fallback can fire from either condition. Push queueing for the deliverable-push path is unchanged.

**Updated: `prayer-global-porch.php`** — loads the new email job class. The `PG_CHANNEL_EMAIL` constant was already defined here (line 30) but had no consumer; this fills that in.

## Behavior matrix

| `notifications_permission` | `push_undeliverable_at` | `emails_permission` | Outcome on new badge |
|---|---|---|---|
| `'1'` | empty | any | Push queued (unchanged) |
| `'1'` | set | `'1'` | Email queued |
| `'1'` | set | not `'1'` | Silent (unchanged) |
| not `'1'` | any | `'1'` | Email queued |
| not `'1'` | any | not `'1'` | Silent (unchanged) |

`PG_Notifications_Sent::is_recent()` continues to dedupe within 48 hours across all channels — a user will never receive both push and email for the same badge.

## Out of scope (follow-ups)

- **No user-facing toggle for `emails_permission` is added here.** The meta key is referenced in the handler's user query but no settings UI sets it today. Once a UI is in place (mirroring the `notifications-permission` REST endpoint at `api/user-api.php:498`), this email path will start firing for opted-in users. Until then this PR is plumbing — wired, but waiting for the toggle.
- Milestone (inactivity) notifications still push-only. Adding email fallback for them is a similar, smaller change and can follow.

## Test plan

- [ ] User with `notifications_permission = '0'` and `emails_permission = '1'` earns a badge → email queued, no push queued
- [ ] User with `notifications_permission = '1'`, `push_undeliverable_at` set, and `emails_permission = '1'` earns a badge → email queued
- [ ] User with `notifications_permission = '1'` and no `push_undeliverable_at` earns a badge → push queued, no email queued (unchanged)
- [ ] User with `emails_permission != '1'` and no push → silent (unchanged)
- [ ] Same badge within 48 hours via either channel → `is_recent` blocks a second send
- [ ] Email body renders correctly across locales (locale switched via `pg_switch_notifications_locale()` in job)