### PR TITLE
Count-based Perfect Week/Month/Year qualification

### DIFF
--- a/classes/badges/pg-badge-manager.php
+++ b/classes/badges/pg-badge-manager.php
@@ -5,6 +5,7 @@ class PG_Badge_Manager {
     private User_Stats $user_stats;
     private PG_Badges $pg_badges;
     private array $month_translations;
+    private array $all_earned_badge_rows = [];
     public function __construct( int $user_id ) {
         $this->user_id = $user_id;
         $this->user_stats = new User_Stats( $user_id );
@@ -27,6 +28,7 @@ class PG_Badge_Manager {
 
     public function get_all_badges(): array {
         $all_earned_badges = PG_Badge_Model::get_all_badges( $this->user_id );
+        $this->all_earned_badge_rows = $all_earned_badges;
         $all_earned_badge_ids = array_column( $all_earned_badges, 'id' );
         $all_badges = $this->pg_badges->get_all_badges();
         $has_processed_monthly_challenge_badges = false;
@@ -251,41 +253,43 @@ class PG_Badge_Manager {
                 }
             }
             if ( $badge->get_type() === PG_Badges::TYPE_MULTIPLE ) {
-                $timestamp = $badge->get_timestamp();
-                $diff_in_days = 1000000;
-                if ( !empty( $timestamp ) ) {
-                    $badge_date = new DateTime( "@$timestamp" );
-                    $badge_date->setTimezone( new DateTimeZone( $this->user_stats->location['time_zone'] ?? 'UTC' ) );
-                    $now_date = new DateTime();
-                    $now_date->setTimezone( new DateTimeZone( $this->user_stats->location['time_zone'] ?? 'UTC' ) );
-                    $diff_in_days = (int) $now_date->diff( $badge_date )->format( '%a' );
+                $period_days_by_id = [
+                    PG_Badges::ID_PERFECT_WEEK  => 7,
+                    PG_Badges::ID_PERFECT_MONTH => 30,
+                    PG_Badges::ID_PERFECT_YEAR  => 365,
+                ];
+                if ( !isset( $period_days_by_id[ $badge->get_id() ] ) ) {
+                    continue;
+                }
+                $period_days = $period_days_by_id[ $badge->get_id() ];
+                $streak_days = $this->user_stats->current_streak_in_days();
+                if ( $streak_days < $period_days ) {
+                    continue;
+                }
 
-                    if ( $badge->is_retroactive() ) {
-                        $diff_in_days = 1000000;
+                // Streak start = midnight of the earliest day in the current streak, in the user's timezone.
+                $tz = new DateTimeZone( $this->user_stats->location['time_zone'] ?? 'UTC' );
+                $streak_start_timestamp = ( new DateTime( 'now', $tz ) )
+                    ->setTime( 0, 0, 0 )
+                    ->modify( '-' . ( $streak_days - 1 ) . ' days' )
+                    ->getTimestamp();
+
+                $periods_completed_in_streak = intdiv( $streak_days, $period_days );
+
+                $periods_credited_in_streak = 0;
+                foreach ( $this->all_earned_badge_rows as $row ) {
+                    if ( $row['id'] !== $badge->get_id() ) {
+                        continue;
+                    }
+                    if ( !empty( $row['retroactive'] ) ) {
+                        continue;
+                    }
+                    if ( (int) $row['timestamp'] >= $streak_start_timestamp ) {
+                        $periods_credited_in_streak++;
                     }
                 }
-                if (
-                    $badge->get_id() === PG_Badges::ID_PERFECT_WEEK &&
-                    $this->user_stats->current_streak_in_days() > 0 &&
-                    $this->user_stats->current_streak_in_days() % 7 === 0 &&
-                    $diff_in_days >= 7 - 1
-                ) {
-                    $newly_earned_badges[] = $badge;
-                }
-                if (
-                    $badge->get_id() === PG_Badges::ID_PERFECT_MONTH &&
-                    $this->user_stats->current_streak_in_days() > 0 &&
-                    $this->user_stats->current_streak_in_days() % 30 === 0 &&
-                    $diff_in_days >= 30 - 1
-                ) {
-                    $newly_earned_badges[] = $badge;
-                }
-                if (
-                    $badge->get_id() === PG_Badges::ID_PERFECT_YEAR &&
-                    $this->user_stats->current_streak_in_days() > 0 &&
-                    $this->user_stats->current_streak_in_days() % 365 === 0 &&
-                    $diff_in_days >= 365 - 1
-                ) {
+
+                if ( $periods_completed_in_streak > $periods_credited_in_streak ) {
                     $newly_earned_badges[] = $badge;
                 }
             }


### PR DESCRIPTION
## Summary

Surfaced during the investigation of #685. The Perfect Week / Perfect Month / Perfect Year qualification in `PG_Badge_Manager::get_newly_earned_badges()` required `current_streak_in_days() % N === 0`, so each badge could only be awarded *on* its anniversary day (day 7, 14, 21, …). If the badge wasn't persisted on that exact day — push opted-out, tab closed mid-session, cron didn't reach that user, etc. — the window closed and the user permanently lost that anniversary, even though they truly earned it.

## Change

In `classes/badges/pg-badge-manager.php`:

1. **Replace the modulo check with a count.** For Perfect Week (`period_days = 7`), Perfect Month (`30`), Perfect Year (`365`):
   - `periods_completed_in_streak = intdiv( current_streak_in_days, period_days )` — how many full periods fit in the current streak.
   - `periods_credited_in_streak` — count of non-retroactive credits of this badge with `timestamp >= streak_start_timestamp`.
   - If `completed > credited`, award one.

2. **Cache the raw `$all_earned_badges` rows on the manager.** `get_all_badges()` already fetches them; storing on `$this->all_earned_badge_rows` lets `get_newly_earned_badges()` see per-instance timestamps without a second DB query.

3. **Streak start = midnight of the earliest day in the streak**, in the user's timezone — so a credit earned on day 1 of a 7-day streak is counted as inside the window, not before it.

4. **Retroactive credits are excluded from the count.** Backfills from migration scripts (`support/migrations/0022-give-badges-retroactively.php`, `support/build/give-badges.php`) shouldn't block a user from earning the badge live.

## Scenarios

| Scenario | Streak | Credits in streak | Completed | Credited | Award? |
|---|---|---|---|---|---|
| Hit day 7 fresh, never had Perfect Week | 7 | 0 | 1 | 0 | ✅ |
| Day 8, day-7 credit was missed | 8 | 0 | 1 | 0 | ✅ (recovery) |
| Day 8, day-7 credited yesterday | 8 | 1 | 1 | 1 | — |
| Day 14, only day-7 credited | 14 | 1 | 2 | 1 | ✅ |
| Day 14, both 7 & 14 credited | 14 | 2 | 2 | 2 | — |
| Day 21, never credited (e.g. push-disabled user clicked Done after #687 lands) | 21 | 0 | 3 | 0 | ✅ → next tick ✅ → next tick ✅ (one per cron run until caught up) |
| Streak broke, restarted, now day 5 | 5 | n/a | n/a | n/a | — (streak < 7) |
| Streak broke, restarted, day 7, prior Perfect Week 4+ days before this streak started | 7 | 0 | 1 | 0 | ✅ |

## Backward compatibility

- Existing earned badges are unaffected (just rows in the DB).
- Existing retroactive credits don't block re-award (same intent as the old `is_retroactive()` → `diff_in_days = 1000000` reset).
- TYPE_MULTIPLE badges with IDs outside `{perfect_week, perfect_month, perfect_year}` are skipped (same as today — those IDs are the only TYPE_MULTIPLE badges defined in `PG_Badges`).
- One award per `get_newly_earned_badges()` call per badge. A user with a 21-day streak and zero credits gets caught up over 3 cron ticks (~45 min). If that's not fast enough, we could change to award `completed - credited` in one go — happy to swap if preferred.

## Test plan

- [ ] User on a 7-day streak with no Perfect Week credits earns Perfect Week
- [ ] User on day 8 with no day-7 credit earns Perfect Week (recovery case)
- [ ] User on day 14 with only a day-7 credit earns a second Perfect Week
- [ ] User on day 14 with both credits earns nothing
- [ ] User on a 6-day streak earns nothing (below threshold)
- [ ] Retroactive credit doesn't block live award
- [ ] Streak broken then restarted — old credits don't count against the new streak
- [ ] Perfect Month at day 30/60/etc., Perfect Year at day 365/etc.